### PR TITLE
Updated automatically, we should work with 5.26 now - fingers crossed

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -9,6 +9,7 @@ use strict;
 use warnings;
 use utf8;
 
+BEGIN { push @INC, '.' }
 use builder::MyBuilder;
 use File::Basename;
 use File::Spec;
@@ -22,9 +23,9 @@ my %args = (
     },
 
     requires => {
-        'Exporter' => '5.57',
         'DateTime' => '0',
         'DateTime::Set' => '0',
+        'Exporter' => '5.57',
     },
 
     recommends => {
@@ -45,7 +46,6 @@ my %args = (
     allow_pureperl => 1,
 
     script_files => [glob('script/*'), glob('bin/*')],
-    c_source     => [qw()],
     PL_files => {},
 
     test_files           => ((-d '.git' || $ENV{RELEASE_TESTING}) && -d 'xt') ? 't/ xt/' : 't/',


### PR DESCRIPTION
Hi @lestrrat 

This PR contains an update from a contemporary Minilla (3.1.11) so tests with Perl version from 5.26 above should work. The Minilla contribution is a adjustment to the inclusion of the current directory in `@INC`, which is no longer the default since Perl 5.26.

I observed the following.

```
Can't locate builder/MyBuilder.pm in @INC (you may need to install the builder::MyBuilder module) (@INC contains: /home/travis/perl5/perlbrew/perls/5.26.3/lib/site_perl/5.26.3/x86_64-linux /home/travis/perl5/perlbrew/perls/5.26.3/lib/site_perl/5.26.3 /home/travis/perl5/perlbrew/perls/5.26.3/lib/5.26.3/x86_64-linux /home/travis/perl5/perlbrew/perls/5.26.3/lib/5.26.3) at Build.PL line 12.

BEGIN failed--compilation aborted at Build.PL line 12.

Failed to execute perl Build.PL: No such file or directory at ./.travis.run line 11.

The command "perl ./.travis.run" exited with 2.
```

Take care and stay safe